### PR TITLE
Start application and its dependencies in bin/twitter.mxs

### DIFF
--- a/bin/twitter.mxs
+++ b/bin/twitter.mxs
@@ -1,4 +1,4 @@
-:application.start(:oauthex)
+Application.Behaviour.start(:oauthex)
 
 defmodule TwitterCli do
 


### PR DESCRIPTION
The behavior of `Application.Behavior.start/1` can be seen in https://github.com/elixir-lang/elixir/blob/master/lib/elixir/lib/application/behaviour.ex#L51-L78.

Fixes #1.
